### PR TITLE
OCD-34: Removal of JSZip library

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -6,7 +6,6 @@
     "datatables.net": "^1.10.16",
     "datatables.net-buttons-dt": "^1.5.1",
     "jquery": "^3.3.1",
-    "jszip": "^2.5.0",
     "react": "^15.6.1",
     "react-dom": "^15.6.1",
     "react-dom-factories": "^1.0.2",

--- a/client/src/js/table.js
+++ b/client/src/js/table.js
@@ -4,7 +4,6 @@ import './../css/datatables.min.css';
 
 const $ = require('jquery');
 $.DataTable = require('datatables.net');
-require('jszip');
 require('datatables.net-buttons');
 require('datatables.net-buttons/js/buttons.html5.js');
 require('datatables.net-buttons/js/buttons.flash.js');


### PR DESCRIPTION
JSZip only required for export of Excel files, not CSV files