### PR TITLE
OCD-62: Addition of DHS metadata link

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ npm-debug.log
 node_modules
 .env*
 /jbrowse/
+client/public/files/
+data/

--- a/client/src/js/dhs.js
+++ b/client/src/js/dhs.js
@@ -38,6 +38,7 @@ class DHSInfo extends Component {
           <a className="grid-item" href={"/files/bed/All-tracks-sorted.bed"} download="All-Tracks.bed">All Tracks</a>
           {list}
         </div>
+        <p><a href={"/files/DHS-Metadata.xlsx"} download="DHS-Metadata.xlsx">Here</a> you can download the DHS metadata, a description of the data samples.</p>
       </div>
     );
   }


### PR DESCRIPTION
Link to metadata file from DHS home page (has been provided by Parisa)
In client/public/files folder